### PR TITLE
Updated GHAs to use a public version of foundry; Ensured MIT license …

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,7 @@ jobs:
           submodules: recursive
 
       - name: Install Foundry
-        run: |
-          curl -sSL https://raw.githubusercontent.com/thrackle-io/foundry/refs/heads/master/foundryup/foundryup -o $HOME/foundryup
-          FOUNDRY_DIR=$HOME/foundry bash $HOME/foundryup --version $(awk '$1~/^[^#]/' script/foundryScripts/foundry.lock)
-          echo "$HOME/foundry/bin" >> $GITHUB_PATH
+        uses: foundry-rs/foundry-toolchain@v1
 
       - name: Install dependencies
         run: |

--- a/src/Float128.sol
+++ b/src/Float128.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 
 /**

--- a/test/Float128.t.f.sol
+++ b/test/Float128.t.f.sol
@@ -1,4 +1,4 @@
-/// SPDX-License-Identifier: UNLICENSED
+/// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
 import "forge-std/console2.sol";

--- a/test/FloatPythonUtils.sol
+++ b/test/FloatPythonUtils.sol
@@ -1,16 +1,10 @@
-/// SPDX-License-Identifier: UNLICENSED
+/// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
 
 contract FloatPythonUtils is Test {
-    function _buildFFIMul128(
-        int aMan,
-        int aExp,
-        int bMan,
-        int bExp,
-        string memory operation
-    ) internal pure returns (string[] memory) {
+    function _buildFFIMul128(int aMan, int aExp, int bMan, int bExp, string memory operation) internal pure returns (string[] memory) {
         string[] memory inputs = new string[](7);
         inputs[0] = "python3";
         inputs[1] = "script/float128_test.py";

--- a/test/GasHelpers.sol
+++ b/test/GasHelpers.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
 contract GasHelpers {
@@ -19,10 +19,7 @@ contract GasHelpers {
         // Subtract 100 to account for the warm SLOAD in startMeasuringGas.
         uint256 gasDelta = checkpointGasLeft - checkpointGasLeft2 - 100;
 
-        emit Gas_Log(
-            string(abi.encodePacked(checkpointLabel, " Gas")),
-            gasDelta
-        );
+        emit Gas_Log(string(abi.encodePacked(checkpointLabel, " Gas")), gasDelta);
         return gasDelta;
     }
 

--- a/test/GasReport.t.sol
+++ b/test/GasReport.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 
 import {Test} from "forge-std/Test.sol";


### PR DESCRIPTION
Updated GHAs to use a public version of foundry

Ensured MIT license is used throughout the Float128 library